### PR TITLE
Manual webhook registrations

### DIFF
--- a/src/main/java/com/unblu/middleware/webhooks/service/WebhookRequestHandlerImpl.java
+++ b/src/main/java/com/unblu/middleware/webhooks/service/WebhookRequestHandlerImpl.java
@@ -52,9 +52,9 @@ public class WebhookRequestHandlerImpl extends RequestQueueServiceImpl implement
         if (middlewareConfiguration.isAutoRegister()) {
             webhookRegistrationService.assertRegistered(eventName);
         } else if (!webhookRegistrationService.isRegisteredFor(eventName)) {
-            throw new RuntimeException("Cannot register handler for event " + eventName +
-                    " because no webhook is registered for it. Either enable auto-registration in the middleware configuration; " +
-                    "or register a webhook for this event prior to this call by calling webhookRegistrationService.assertRegistered(eventName).");
+            log.info("While registering a handler for webhook event {}, we detected that the event was not registered " +
+                    "in an Unblu webhook registration managed by the webhookRegistrationService and the library is " +
+                    "not configured to auto-register webhooks. Make sure you registered it manually.", eventName);
         }
     }
 


### PR DESCRIPTION
Info message instead of exception when registering a webhook event handler, autoRegister = false & event not registered with webhookRegistrationService.

An alternative might be to introduce yet another property named e.g. `registrationsManagedExternally`, keep the exception in place but only if the new property is false. But that would introduce a bit of a mess if setting `autoRegister` to true - we'd have to e.g. say that if the new property would be true, `autoRegister` would be disregarded. What do you think?