### PR TITLE
Bootstrapped object mapper (as well as the one for copying objects) now uses jerseyJsonResolver configuration

### DIFF
--- a/src/main/java/com/unblu/middleware/common/bootstrap/MiddlewareLibBootstrap.java
+++ b/src/main/java/com/unblu/middleware/common/bootstrap/MiddlewareLibBootstrap.java
@@ -1,6 +1,7 @@
 package com.unblu.middleware.common.bootstrap;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.unblu.webapi.jersey.v4.invoker.JSON;
 import io.micrometer.context.ContextRegistry;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -23,7 +24,12 @@ public class MiddlewareLibBootstrap {
     }
 
     @Bean
-    public ObjectMapper objectMapper() {
-        return new ObjectMapper();
+    public JSON jerseyJsonResolver() {
+        return new JSON();
+    }
+
+    @Bean
+    public ObjectMapper objectMapper(JSON jerseyJsonResolver) {
+        return jerseyJsonResolver.getContext(Object.class);
     }
 }

--- a/src/main/java/com/unblu/middleware/common/utils/ObjectUtils.java
+++ b/src/main/java/com/unblu/middleware/common/utils/ObjectUtils.java
@@ -2,12 +2,13 @@ package com.unblu.middleware.common.utils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.unblu.webapi.jersey.v4.invoker.JSON;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class ObjectUtils {
 
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper objectMapper = new JSON().getContext(Object.class).copy();
 
     @SuppressWarnings("unchecked")
     public static <T> T copyOf(T registration) {


### PR DESCRIPTION
Attempting to resolve forward ser/de compatibility issues